### PR TITLE
Fix how CSS files are added

### DIFF
--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -179,12 +179,6 @@ except ImportError:
 
 html_static_path = ['sphinx-static']
 
-html_context = {
-    'css_files': [
-        '_static/theme_overrides.css',
-    ],
-}
-
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
 # directly to the root of the documentation.
@@ -419,3 +413,11 @@ pdf_documents = [
 # line arguments.
 kerneldoc_bin = '../scripts/kernel-doc'
 kerneldoc_srctree = '..'
+
+
+def setup(app):
+    """
+    This is a basic Sphinx extension that adds our CSS overrides.
+    """
+    app.add_stylesheet('_static/theme_overrides.css')
+    


### PR DESCRIPTION
This uses the proper Sphinx add_stylesheet API for adding style overrides:

http://www.sphinx-doc.org/en/stable/extdev/appapi.html#sphinx.application.Sphinx.add_stylesheet
